### PR TITLE
Explicitly use mb_string functions where we deal with user-facing str…

### DIFF
--- a/Building/Building.php
+++ b/Building/Building.php
@@ -101,12 +101,7 @@ class Building
 
 	public static function setupGettext()
 	{
-		$path = '@DATA-DIR@/Building/locale';
-		if (substr($path, 0, 1) === '@') {
-			$path = __DIR__.'/../locale';
-		}
-
-		bindtextdomain(self::GETTEXT_DOMAIN, $path);
+		bindtextdomain(self::GETTEXT_DOMAIN, __DIR__.'/../locale');
 		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
 	}
 

--- a/Building/views/BuildingBlockAttachmentView.php
+++ b/Building/views/BuildingBlockAttachmentView.php
@@ -105,7 +105,7 @@ class BuildingBlockAttachmentView extends BuildingBlockView
 
 			$mime_type_class = sprintf(
 				'building-block-attachment-icon-%s',
-				strtolower(
+				mb_strtolower(
 					str_replace(
 						'/',
 						'-',

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 	],
 	"require": {
 		"php": ">=5.2.1",
+		"ext-mbstring": "*",
 		"silverorange/admin": "^3.0.0",
 		"silverorange/site": "^5.0.0",
 		"silverorange/swat": "^3.0.0"


### PR DESCRIPTION
…ings

This allows us to turn off mb_string.func_overload.