### PR TITLE
Switching the order type needs to be in the init or order isn't saved

### DIFF
--- a/Building/admin/components/Block/Order.php
+++ b/Building/admin/components/Block/Order.php
@@ -2,11 +2,26 @@
 
 /**
  * @package   Building
- * @copyright 2014-2016 silverorange
+ * @copyright 2014-2019 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 abstract class BuildingBlockOrder extends AdminOrder
 {
+	// init phase
+	// {{{ protected function initInternal()
+
+	protected function initInternal()
+	{
+		parent::initInternal();
+
+		// auto ordering doesn't make sense for blocks
+		$options_list = $this->ui->getWidget('options');
+		$options_list->parent->visible = false;
+		$options_list->value = 'custom';
+	}
+
+	// }}}
+
 	// process phase
 	// {{{ protected function saveIndex()
 
@@ -46,11 +61,6 @@ abstract class BuildingBlockOrder extends AdminOrder
 			$view->display($block);
 			$order_widget->addOption($block->id, ob_get_clean(), 'text/xml');
 		}
-
-		// auto ordering doesn't make sense for blocks
-		$options_list = $this->ui->getWidget('options');
-		$options_list->parent->visible = false;
-		$options_list->value = 'custom';
 	}
 
 	// }}}

--- a/Building/admin/components/Block/Order.php
+++ b/Building/admin/components/Block/Order.php
@@ -2,7 +2,7 @@
 
 /**
  * @package   Building
- * @copyright 2014-2019 silverorange
+ * @copyright 2014-2020 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 abstract class BuildingBlockOrder extends AdminOrder


### PR DESCRIPTION
The problem is that the order type is always "auto" in the process step https://github.com/silverorange/admin/blob/master/Admin/pages/AdminOrder.php#L81

To test:
 - check out this PR in the building package dir `/so/packages/building/work-{username}`
 - in the emrap dir `/so/sites/emrap/work-{username}/`, run `gulp --symlinks=building`
 - go this chapter in the admin https://berna.silverorange.com/emrap/work-{username}/www/admin/Chapter/Details?id=46089
 - try re-ordering the content blocks
 - before, the order would not be saved and both would just have `displayorder = 0`