### PR TITLE
Add dataobjects

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -3,7 +3,7 @@ name: Pull Requests
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   runner:

--- a/Building/Building.php
+++ b/Building/Building.php
@@ -102,31 +102,31 @@ class Building
         SiteViewFactory::addPath('Building/views');
         SiteViewFactory::registerView(
             'building-block-audio',
-            'BuildingBlockAudioView'
+            BuildingBlockAudioView::class
         );
         SiteViewFactory::registerView(
             'building-block-video',
-            'BuildingBlockVideoView'
+            BuildingBlockVideoView::class
         );
         SiteViewFactory::registerView(
             'building-block-image',
-            'BuildingBlockImageView'
+            BuildingBlockImageView::class
         );
         SiteViewFactory::registerView(
             'building-block-xhtml',
-            'BuildingBlockXHTMLView'
+            BuildingBlockXHTMLView::class
         );
         SiteViewFactory::registerView(
             'building-block-attachment',
-            'BuildingBlockAttachmentView'
+            BuildingBlockAttachmentView::class
         );
         SiteViewFactory::registerView(
             'building-block',
-            'BuildingBlockCompositeView'
+            BuildingBlockCompositeView::class
         );
         SiteViewFactory::registerView(
             'building-block-admin',
-            'BuildingBlockAdminCompositeView'
+            BuildingBlockAdminCompositeView::class
         );
 
         SwatUI::mapClassPrefixToPath('Building', 'Building');

--- a/Building/BuildingBlockViewFactory.php
+++ b/Building/BuildingBlockViewFactory.php
@@ -36,18 +36,19 @@ class BuildingBlockViewFactory
      */
     public static function getViewType(BuildingBlock $block)
     {
-        $type = 'building-block-xhtml';
-
         if ($block->media instanceof SiteAudioMedia) {
-            $type = 'building-block-audio';
-        } elseif ($block->media instanceof SiteVideoMedia) {
-            $type = 'building-block-video';
-        } elseif ($block->image instanceof SiteImage) {
-            $type = 'building-block-image';
-        } elseif ($block->attachment instanceof SiteAttachment) {
-            $type = 'building-block-attachment';
+            return 'building-block-audio';
+        }
+        if ($block->media instanceof SiteVideoMedia) {
+            return 'building-block-video';
+        }
+        if ($block->image instanceof SiteImage) {
+            return 'building-block-image';
+        }
+        if ($block->attachment instanceof SiteAttachment) {
+            return 'building-block-attachment';
         }
 
-        return $type;
+        return 'building-block-xhtml';
     }
 }

--- a/Building/admin/components/Block/AttachmentEdit.php
+++ b/Building/admin/components/Block/AttachmentEdit.php
@@ -28,7 +28,7 @@ class BuildingBlockAttachmentEdit extends BuildingBlockEdit
                 $this->attachment_set =
                     $this->getObject()->attachment->attachment_set;
             } else {
-                $class_name = SwatDBClassMap::get('SiteAttachmentSet');
+                $class_name = SwatDBClassMap::get(SiteAttachmentSet::class);
                 $this->attachment_set = new $class_name();
                 $this->attachment_set->setDatabase($this->app->db);
                 $shortname = $this->getAttachmentSetShortname();
@@ -48,7 +48,7 @@ class BuildingBlockAttachmentEdit extends BuildingBlockEdit
 
     protected function getNewAttachmentInstance()
     {
-        $class_name = SwatDBClassMap::get('SiteAttachment');
+        $class_name = SwatDBClassMap::get(SiteAttachment::class);
         $attachment = new $class_name();
         $attachment->setDatabase($this->app->db);
         $attachment->attachment_set = $this->getAttachmentSet();

--- a/Building/admin/components/Block/AttachmentEdit.php
+++ b/Building/admin/components/Block/AttachmentEdit.php
@@ -28,8 +28,7 @@ class BuildingBlockAttachmentEdit extends BuildingBlockEdit
                 $this->attachment_set =
                     $this->getObject()->attachment->attachment_set;
             } else {
-                $class_name = SwatDBClassMap::get(SiteAttachmentSet::class);
-                $this->attachment_set = new $class_name();
+                $this->attachment_set = SwatDBClassMap::new(SiteAttachmentSet::class);
                 $this->attachment_set->setDatabase($this->app->db);
                 $shortname = $this->getAttachmentSetShortname();
                 if (!$this->attachment_set->loadByShortname($shortname)) {
@@ -48,8 +47,7 @@ class BuildingBlockAttachmentEdit extends BuildingBlockEdit
 
     protected function getNewAttachmentInstance()
     {
-        $class_name = SwatDBClassMap::get(SiteAttachment::class);
-        $attachment = new $class_name();
+        $attachment = SwatDBClassMap::new(SiteAttachment::class);
         $attachment->setDatabase($this->app->db);
         $attachment->attachment_set = $this->getAttachmentSet();
 

--- a/Building/admin/components/Block/Delete.php
+++ b/Building/admin/components/Block/Delete.php
@@ -38,7 +38,7 @@ class BuildingBlockDelete extends AdminDBDelete
                 'select * from Block where id in (%s)',
                 $this->getItemList('integer')
             ),
-            SwatDBClassMap::get('BuildingBlockWrapper')
+            SwatDBClassMap::get(BuildingBlockWrapper::class)
         );
 
         $view = SiteViewFactory::get($this->app, 'building-block');

--- a/Building/admin/components/Block/Edit.php
+++ b/Building/admin/components/Block/Edit.php
@@ -8,7 +8,7 @@ abstract class BuildingBlockEdit extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'BuildingBlock';
+        return BuildingBlock::class;
     }
 
     // process phase

--- a/Building/admin/components/Block/ImageEdit.php
+++ b/Building/admin/components/Block/ImageEdit.php
@@ -27,7 +27,7 @@ class BuildingBlockImageEdit extends BuildingBlockEdit
             if ($this->getObject()->image instanceof SiteImage) {
                 $this->image_set = $this->getObject()->image->image_set;
             } else {
-                $class_name = SwatDBClassMap::get('SiteImageSet');
+                $class_name = SwatDBClassMap::get(SiteImageSet::class);
                 $this->image_set = new $class_name();
                 $this->image_set->setDatabase($this->app->db);
                 $shortname = $this->getImageSetShortname();
@@ -47,7 +47,7 @@ class BuildingBlockImageEdit extends BuildingBlockEdit
 
     protected function getNewImageInstance()
     {
-        $class_name = SwatDBClassMap::get('SiteImage');
+        $class_name = SwatDBClassMap::get(SiteImage::class);
         $image = new $class_name();
         $image->setDatabase($this->app->db);
         $image->image_set = $this->getImageSet();

--- a/Building/admin/components/Block/ImageEdit.php
+++ b/Building/admin/components/Block/ImageEdit.php
@@ -27,8 +27,7 @@ class BuildingBlockImageEdit extends BuildingBlockEdit
             if ($this->getObject()->image instanceof SiteImage) {
                 $this->image_set = $this->getObject()->image->image_set;
             } else {
-                $class_name = SwatDBClassMap::get(SiteImageSet::class);
-                $this->image_set = new $class_name();
+                $this->image_set = SwatDBClassMap::new(SiteImageSet::class);
                 $this->image_set->setDatabase($this->app->db);
                 $shortname = $this->getImageSetShortname();
                 if (!$this->image_set->loadByShortname($shortname)) {
@@ -47,8 +46,7 @@ class BuildingBlockImageEdit extends BuildingBlockEdit
 
     protected function getNewImageInstance()
     {
-        $class_name = SwatDBClassMap::get(SiteImage::class);
-        $image = new $class_name();
+        $image = SwatDBClassMap::new(SiteImage::class);
         $image->setDatabase($this->app->db);
         $image->image_set = $this->getImageSet();
 

--- a/Building/admin/components/Block/VideoEdit.php
+++ b/Building/admin/components/Block/VideoEdit.php
@@ -24,6 +24,7 @@ class BuildingBlockVideoEdit extends BuildingBlockEdit
             } else {
                 $media_id = $this->app->initVar('media');
                 if ($media_id === null) {
+                    /** @var SwatForm $form */
                     $form = $this->ui->getWidget('edit_form');
                     $media_id = $form->getHiddenField('media');
                 }
@@ -92,12 +93,16 @@ class BuildingBlockVideoEdit extends BuildingBlockEdit
         $media = $this->getMedia();
         $media->setFileBase('media');
 
-        $this->ui->getWidget('edit_form')->addHiddenField('media', $media->id);
+        /** @var SwatForm $form */
+        $form = $this->ui->getWidget('edit_form');
+        $form->addHiddenField('media', $media->id);
 
         $player = $media->getMediaPlayer($this->app);
         ob_start();
         $player->display();
-        $this->ui->getWidget('player')->content = ob_get_clean();
+        /** @var SwatContentBlock $ui_player */
+        $ui_player = $this->ui->getWidget('player');
+        $ui_player->content = ob_get_clean();
         $this->layout->addHtmlHeadEntrySet($player->getHtmlHeadEntrySet());
     }
 

--- a/Building/admin/components/Block/VideoEdit.php
+++ b/Building/admin/components/Block/VideoEdit.php
@@ -28,7 +28,7 @@ class BuildingBlockVideoEdit extends BuildingBlockEdit
                     $media_id = $form->getHiddenField('media');
                 }
 
-                $class_name = SwatDBClassMap::get('SiteVideoMedia');
+                $class_name = SwatDBClassMap::get(SiteVideoMedia::class);
                 $this->media = new $class_name();
                 $this->media->setDatabase($this->app->db);
                 if (!$this->media->load($media_id)) {

--- a/Building/admin/components/Block/VideoEdit.php
+++ b/Building/admin/components/Block/VideoEdit.php
@@ -28,8 +28,7 @@ class BuildingBlockVideoEdit extends BuildingBlockEdit
                     $media_id = $form->getHiddenField('media');
                 }
 
-                $class_name = SwatDBClassMap::get(SiteVideoMedia::class);
-                $this->media = new $class_name();
+                $this->media = SwatDBClassMap::new(SiteVideoMedia::class);
                 $this->media->setDatabase($this->app->db);
                 if (!$this->media->load($media_id)) {
                     throw new AdminNotFoundException(

--- a/Building/dataobjects/BuildingBlock.php
+++ b/Building/dataobjects/BuildingBlock.php
@@ -6,11 +6,6 @@
  * @copyright 2014-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  *
- * @property int             $id
- * @property ?string         $bodytext
- * @property ?int            $displayorder
- * @property ?SwatDate       $createdate
- * @property ?SwatDate       $modified_date
  * @property ?SiteAttachment $attachment
  * @property ?SiteImage      $image
  * @property ?SiteVideoMedia $media
@@ -23,7 +18,7 @@ class BuildingBlock extends SwatDBDataObject
     public $id;
 
     /**
-     * @var string
+     * @var ?string
      */
     public $bodytext;
 

--- a/Building/dataobjects/BuildingBlock.php
+++ b/Building/dataobjects/BuildingBlock.php
@@ -5,6 +5,15 @@
  *
  * @copyright 2014-2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ *
+ * @property int             $id
+ * @property ?string         $bodytext
+ * @property ?int            $displayorder
+ * @property ?SwatDate       $createdate
+ * @property ?SwatDate       $modified_date
+ * @property ?SiteAttachment $attachment
+ * @property ?SiteImage      $image
+ * @property ?SiteVideoMedia $media
  */
 class BuildingBlock extends SwatDBDataObject
 {

--- a/Building/dataobjects/BuildingBlock.php
+++ b/Building/dataobjects/BuildingBlock.php
@@ -44,17 +44,17 @@ class BuildingBlock extends SwatDBDataObject
 
         $this->registerInternalProperty(
             'attachment',
-            SwatDBClassMap::get('SiteAttachment')
+            SwatDBClassMap::get(SiteAttachment::class)
         );
 
         $this->registerInternalProperty(
             'image',
-            SwatDBClassMap::get('SiteImage')
+            SwatDBClassMap::get(SiteImage::class)
         );
 
         $this->registerInternalProperty(
             'media',
-            SwatDBClassMap::get('SiteVideoMedia')
+            SwatDBClassMap::get(SiteVideoMedia::class)
         );
 
         $this->id_field = 'integer:id';

--- a/Building/dataobjects/BuildingBlockWrapper.php
+++ b/Building/dataobjects/BuildingBlockWrapper.php
@@ -13,7 +13,7 @@ class BuildingBlockWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = SwatDBClassMap::get('BuildingBlock');
+        $this->row_wrapper_class = SwatDBClassMap::get(BuildingBlock::class);
         $this->index_field = 'id';
     }
 }


### PR DESCRIPTION
# Description

- Converts `'SomeClass'` to `SomeClass::class` throughout
- uses `SwatDBClassMap::new()` instead of instantiating class-name variables
- adds dataobject docblocks to the (one) data object class
- minor other changes to PHP logic and type hinting to help with static analysis

# Testing Instructions (optional)

Add step-by-step instructions for testing the PR, if necessary.

1. Check out this PR
2. CI should pass

# Developer Checklist

Before requesting review for this PR, make sure the following tasks are
complete:

- [ ] I added a link to the relevant Shortcut story, if applicable
- [ ] I added testing instructions, if any
- [ ] I made sure existing CI checks pass
- [ ] I checked that all requirements of the ticket are fulfilled

# Reviewer Checklist

Before merging this PR, make sure the following tasks are complete:

- [x] I made sure there are no active labels that block merge
- [ ] I followed the testing instructions
- [x] I made sure the CI checks pass
- [x] I reviewed the file changes on GitHub
- [ ] I checked that all requirements of the ticket (if any) are fulfilled
